### PR TITLE
Add 07087L - Immax 4-Key Remote Controller deviece

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -6188,6 +6188,28 @@ const devices = [
             await configureReporting.activePower(endpoint);
         },
     },
+        {
+        zigbeeModel: ['Remote-control-ZB3.0'],
+        model: '07087L',
+        vendor: 'Immax',
+        description: '4-Key Remote Controller',
+        supports: 'on/off, brightness up/down and click/hold/release, cct',
+        fromZigbee: [
+            fz.CCTSwitch_D0001_on_off,
+            fz.CCTSwitch_D0001_move_to_level_recall,
+            fz.CCTSwitch_D0001_move_to_colortemp_recall,
+            fz.CCTSwitch_D0001_colortemp_updown_hold_release,
+            fz.CCTSwitch_D0001_brightness_updown_hold_release,
+            fz.legacy_battery,
+        ],
+        toZigbee: [],
+        meta: {configureKey: 1},
+        configure: async (device, coordinatorEndpoint) => {
+            const endpoint = device.getEndpoint(1);
+            await bind(endpoint, coordinatorEndpoint, ['genPowerCfg']);
+            await configureReporting.batteryPercentageRemaining(endpoint);
+        },
+    },
 
     // Yale
     {


### PR DESCRIPTION
Added 07087L - Immax 4-Key Remote Controller
https://zigbeealliance.org/zigbee_products/immax-neo-cct-remote-control/

it have same functions as Leedarson 4-Key Remote Controller (on/off, brightness up/down and click/hold/release, cct)
6ARCZABZH

this i get on connection :
{
    "ieeeAddr": "0xec1bbdfffe316e4c",
    "applicationVersion": 2,
    "dateCode": "20191019-7",
    "endpoints": [
        {
            "ID": 1,
            "clusters": {
                "genBasic": {
                    "attributes": {
                        "modelId": "Remote-control-ZB3.0",
                        "manufacturerName": "Immax",
                        "powerSource": 3,
                        "zclVersion": 3,
                        "appVersion": 2,
                        "stackVersion": 6,
                        "hwVersion": 1,
                        "dateCode": "20191019-7",
                        "swBuildId": "2.08"
                    }
                }
            },
            "deviceNetworkAddress": 56155,
            "deviceIeeeAddr": "0xec1bbdfffe316e4c",
            "inputClusters": [
                0,
                1,
                3,
                4096,
                64769
            ],
            "outputClusters": [
                3,
                4,
                6,
                8,
                25,
                768,
                4096
            ],
            "profileID": 260,
            "binds": []
        }
    ],
    "hardwareVersion": 1,
    "interviewCompleted": true,
    "interviewing": false,
    "lastSeen": 1585348384674,
    "manufacturerID": 4151,
    "manufacturerName": "Immax",
    "modelID": "Remote-control-ZB3.0",
    "networkAddress": 56155,
    "powerSource": "Battery",
    "softwareBuildID": "2.08",
    "stackVersion": 6,
    "type": "EndDevice",
    "zclVersion": 3,
    "meta": {
        "name": "Remote",
        "offline": false
    }
}